### PR TITLE
Changed path to "Remote Desktop Connection" app

### DIFF
--- a/lib/vagrant-rdp/command.rb
+++ b/lib/vagrant-rdp/command.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
           rdp_file = rdp_file(vm, rdpport)
 
           tf.puts <<EOS
-open -a "/Applications/Microsoft Remote Desktop.app/Contents/MacOS/Microsoft Remote Desktop" "#{rdp_file}"
+open -a "/Applications/Remote Desktop Connection.app/Contents/MacOS/Remote Desktop Connection" "#{rdp_file}"
 sleep 5 #HACK
 rm "#{rdp_file}"
 EOS


### PR DESCRIPTION
I could not get this plugin to work for me on Vagrant 1.6.3, but at least one thing seemed wrong to me there - path to RDC application (ver. 2.1.1), which I got from: http://www.microsoft.com/en-us/download/details.aspx?id=18140
